### PR TITLE
reinstate saveAbsolutePath

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,11 @@
                     "default": true,
                     "markdownDescription": "save group globally when no workspace is opened\n\n require `#saveEditorLayout.saveToGlobal#` to be set to false"
                 },
+                "saveEditorLayout.saveAbsolutePath": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "save file path as full absolute path (if false, then save it as relative to the workspace root)"
+                },
                 "saveEditorLayout.restoreLayoutOnly": {
                     "type": "boolean",
                     "default": false,
@@ -192,7 +197,7 @@
     "devDependencies": {
         "@types/node": "^24.2.1",
         "@types/vscode": "^1.100.0",
-        "esbuild": "^0.25.9",
+        "esbuild": "0.25.12",
         "typescript": "^5.9.2"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import vscode from 'vscode'
+import path from 'path'
 import TreeProvider from './TreeProvider'
 import * as utils from './util'
 
@@ -97,7 +98,9 @@ async function save() {
 
 function getSortedSaveList(tabs = null) {
     return sortList(tabs || getOpenedTabsWithoutUntitled()).map((tab: vscode.Tab) => ({
-        fsPath: tab.input?.uri?.fsPath,
+        fsPath: utils.config.saveAbsolutePath
+                ? tab.input?.uri?.fsPath
+                : vscode.workspace.asRelativePath(tab.input?.uri?.fsPath),
         column: tab.group.viewColumn,
         pinned: tab.isPinned,
     }))
@@ -280,7 +283,10 @@ function sortList(arr: vscode.Tab[]) {
 
 async function showDocument(doc) {
     try {
-        const document = await vscode.workspace.openTextDocument(doc.fsPath)
+        const resolvedPath = path.isAbsolute(doc.fsPath)
+            ? doc.fsPath
+            : path.join(vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '', doc.fsPath)
+        const document = await vscode.workspace.openTextDocument(resolvedPath)
 
         await vscode.window.showTextDocument(document, {
             viewColumn: doc.column,


### PR DESCRIPTION
Brings back the setting to select whether to store absolute or relative paths.
This is crucial when saving groups to global config and syncing with other machines.